### PR TITLE
Fix problem with finding libc.so (check also for libc.6.so)

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -705,41 +705,7 @@ if test "$HAVEMETHOD" = "no"; then
     dnl Make sure we use libld if necessary -- CPK
     LIBS="$LIBDL $LIBS"
 
-    dnl ugly, ugly hack		     
-    LIBCGUESS=`echo /lib/libc.so.*`
-    LIBCGUESS64=`echo /lib/x86_64-linux-gnu/libc.so.*`
-    LIBCGUESS386=`echo /lib/i386-linux-gnu/libc.so.*`
-
-    USRLIBCGUESS=`echo /usr/lib/libc.so.*`
-    USRLIBCGUESS64=`echo /usr/lib/x86_64-linux-gnu/libc.so.*`
-    USRLIBCGUESS386=`echo /usr/lib/i386-linux-gnu/libc.so.*`
-    
-    if test "$USRLIBCGUESS" = "/usr/lib/libc.so.*"; then
-       USRLIBCGUESS=""
-    fi
-    
-    if test "$LIBCGUESS" = "/lib/libc.so.*"; then
-       LIBCGUESS=""
-    fi
-    
-    if test "$LIBCGUESS386" = "/lib/i386-linux-gnu/libc.so.*"; then
-       LIBCGUESS386=""
-    fi
-    
-    if test "$USRLIBCGUESS386" = "/usr/lib/i386-linux-gnu/libc.so.*"; then
-       USRLIBCGUESS386=""
-    fi
-    
-    if test "$USRLIBCGUESS64" = "/usr/lib/x86_64-linux-gnu/libc.so.*"; then
-       USRLIBCGUESS64=""
-    fi
-    
-    if test "$LIBCGUESS64" = "/lib/x86_64-linux-gnu/libc.so.*"; then
-       LIBCGUESS64=""
-    fi
-    
-    
-    for TESTLIB in libc.so `echo $USRLIBCGUESS` `echo $LIBCGUESS` `echo $LIBCGUESS386` `echo $USRLIBCGUESS386` `echo $USRLIBCGUESS64` `echo $LIBCGUESS64`
+    for TESTLIB in libc.so libc.so.6
     do
         AC_MSG_CHECKING(if we can access libc with $TESTLIB)
         AC_TRY_RUN(


### PR DESCRIPTION
Fixes problems finding libc.so on Raspberry Pi, also gets rid of the ugly hack where we check for a bunch of architecture specific folders to find libc. The problem was just that libc.so got renamed to libc.so.6 in newer versions of glib. Calling that with dlopen works without having to do all of the manual path nonsense.
