### PR TITLE
Fix Python version bug

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -230,7 +230,7 @@ install-data-local:
 	find $(DESTDIR)$(honeyddatadir)/webserver -type d | xargs chmod a+xr
 	(cd $(top_srcdir) && tar -cf - $(top_srcdir)/scripts) | \
 	(cd $(DESTDIR)$(honeyddatadir) && tar -xf -)
-	python $(DESTDIR)$(honeyddatadir)/scripts/lib/init.py
+	python2 $(DESTDIR)$(honeyddatadir)/scripts/lib/init.py
 
 CLEANFILES = *.so
 DISTCLEANFILES = *~


### PR DESCRIPTION
Use python2 instead of python, because python might refer to python3
(e.g. under Arch Linux).